### PR TITLE
Redesign theme system with 6 color palettes and new fonts

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -1,12 +1,8 @@
 # site properties and page defaults
 title: DRACO
 subtitle: Design of Resilient Architectures for Computing
-<<<<<<< claude/analyze-jekyll-site-l3Bw8
 description: "DRACO Lab at UCF: applied research in hardware security, side channel analysis, and resilient computing — from logic gates to autonomous systems."
-=======
-description: "DRACO Lab at UCF explores secure and resilient computing at the intersection of hardware, embedded systems, and AI."
 url: "https://thedracolab.com"
->>>>>>> main
 header: images/2025-draco-par-team.jpg
 footer: images/Reflection_Pond_01.jpg
 proofer: false

--- a/_includes/fonts.html
+++ b/_includes/fonts.html
@@ -1,10 +1,7 @@
 <!-- Google Fonts -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
-
-<!-- Clash Display (via Fontshare) -->
-<link href="https://api.fontshare.com/v2/css?f[]=clash-display@400,500,600,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;500;600;700;800;900&family=Exo+2:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
 
 <!-- Font Awesome icons (load asynchronously due to size) -->
 {% assign fontawesome = "https://use.fontawesome.com/releases/v6.5.0/css/all.css" %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -34,11 +34,5 @@
     </a>
   </div>
 
-  <input
-    type="checkbox"
-    class="dark-toggle"
-    data-tooltip="Dark mode"
-    aria-label="toggle dark mode"
-    oninput="onDarkToggleChange(event)"
-  >
+  <div class="theme-picker" aria-label="Color theme"></div>
 </footer>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-dark="false">
+<html lang="en" data-dark="true" data-theme="deep-space">
   {% include head.html %}
   <body>
     <a class="skip-link" href="#main-content">Skip to content</a>

--- a/_scripts/dark-mode.js
+++ b/_scripts/dark-mode.js
@@ -1,25 +1,50 @@
 /*
-  manages light/dark mode.
+  manages color theme selection.
 */
 
 {
-  // immediately load saved (or default) mode before page renders
-  document.documentElement.dataset.dark =
-    window.localStorage.getItem("dark-mode") ?? "false";
+  const themes = [
+    { id: "deep-space", label: "Deep Space" },
+    { id: "nebula", label: "Nebula" },
+    { id: "aurora", label: "Aurora" },
+    { id: "solar-flare", label: "Solar Flare" },
+    { id: "ucf-knight", label: "UCF Knight" },
+    { id: "lunar-surface", label: "Lunar" },
+  ];
+
+  // immediately load saved (or default) theme before page renders
+  const saved = window.localStorage.getItem("color-theme") || "deep-space";
+  document.documentElement.dataset.theme = saved;
+  // keep data-dark true for all themes (all are dark)
+  document.documentElement.dataset.dark = "true";
 
   const onLoad = () => {
-    // update toggle button to match loaded mode
-    document.querySelector(".dark-toggle").checked =
-      document.documentElement.dataset.dark === "true";
+    // build the theme picker dots
+    const picker = document.querySelector(".theme-picker");
+    if (!picker) return;
+
+    themes.forEach((t) => {
+      const dot = document.createElement("button");
+      dot.className = "theme-dot";
+      dot.dataset.theme = t.id;
+      dot.setAttribute("aria-label", t.label + " theme");
+      dot.setAttribute("data-tooltip", t.label);
+      if (t.id === saved) dot.classList.add("active");
+      dot.addEventListener("click", () => selectTheme(t.id));
+      picker.appendChild(dot);
+    });
   };
 
-  // after page loads
+  const selectTheme = (id) => {
+    document.documentElement.dataset.theme = id;
+    window.localStorage.setItem("color-theme", id);
+    document.querySelectorAll(".theme-dot").forEach((d) => {
+      d.classList.toggle("active", d.dataset.theme === id);
+    });
+  };
+
+  // expose for inline use
+  window.selectTheme = selectTheme;
+
   window.addEventListener("load", onLoad);
-
-  // when user toggles mode button
-  window.onDarkToggleChange = (event) => {
-    const value = event.target.checked;
-    document.documentElement.dataset.dark = value;
-    window.localStorage.setItem("dark-mode", value);
-  };
 }

--- a/_styles/-theme.scss
+++ b/_styles/-theme.scss
@@ -1,20 +1,9 @@
 ---
 ---
 
-// colors
-[data-dark="false"] {
-  --primary: #1d4ed8;
-  --secondary: #bfdbfe;
-  --accent: #06b6d4;
-  --text: #0f172a;
-  --background: #f0f5ff;
-  --background-alt: #e0eafc;
-  --light-gray: #b8cceb;
-  --gray: #4b6a9b;
-  --dark-gray: #1e3a5f;
-  --overlay: #0a2a5a0d;
-}
-[data-dark="true"] {
+// color themes — all dark/blue UCF + space palettes
+// Deep Space (default)
+[data-theme="deep-space"], :root {
   --primary: #60a5fa;
   --secondary: #1e3a5f;
   --accent: #22d3ee;
@@ -25,13 +14,89 @@
   --gray: #6b8fc4;
   --dark-gray: #a3c4f0;
   --overlay: #2563eb08;
+  --theme-dot: #60a5fa;
+}
+
+// Nebula
+[data-theme="nebula"] {
+  --primary: #a78bfa;
+  --secondary: #2e1065;
+  --accent: #c084fc;
+  --text: #e8e0f7;
+  --background: #0c0820;
+  --background-alt: #150f2e;
+  --light-gray: #2e1f5e;
+  --gray: #9484bf;
+  --dark-gray: #c8b8e8;
+  --overlay: #7c3aed08;
+  --theme-dot: #a78bfa;
+}
+
+// Aurora
+[data-theme="aurora"] {
+  --primary: #34d399;
+  --secondary: #0f3d2e;
+  --accent: #22d3ee;
+  --text: #d6f5ea;
+  --background: #04120e;
+  --background-alt: #091f19;
+  --light-gray: #1a3d33;
+  --gray: #6bbfa3;
+  --dark-gray: #a8e6cf;
+  --overlay: #10b98108;
+  --theme-dot: #34d399;
+}
+
+// Solar Flare
+[data-theme="solar-flare"] {
+  --primary: #fbbf24;
+  --secondary: #3d2800;
+  --accent: #f97316;
+  --text: #fef3c7;
+  --background: #0f0a02;
+  --background-alt: #1a1206;
+  --light-gray: #3d2e10;
+  --gray: #c49a4a;
+  --dark-gray: #f5d98a;
+  --overlay: #d9760008;
+  --theme-dot: #fbbf24;
+}
+
+// UCF Knight
+[data-theme="ucf-knight"] {
+  --primary: #ffc904;
+  --secondary: #2a2200;
+  --accent: #ffd740;
+  --text: #f5edd0;
+  --background: #0a0a0a;
+  --background-alt: #141414;
+  --light-gray: #2e2e2e;
+  --gray: #a89860;
+  --dark-gray: #d4c484;
+  --overlay: #ffc90408;
+  --theme-dot: #ffc904;
+}
+
+// Lunar Surface
+[data-theme="lunar-surface"] {
+  --primary: #94a3b8;
+  --secondary: #1e293b;
+  --accent: #cbd5e1;
+  --text: #e2e8f0;
+  --background: #0b0f18;
+  --background-alt: #111827;
+  --light-gray: #1e293b;
+  --gray: #7b8ba3;
+  --dark-gray: #b8c8dc;
+  --overlay: #64748b08;
+  --theme-dot: #94a3b8;
 }
 
 :root {
   // font families
-  --title: "Clash Display", "DM Sans", sans-serif;
-  --heading: "DM Sans", sans-serif;
-  --body: "DM Sans", sans-serif;
+  --title: "Orbitron", "Exo 2", sans-serif;
+  --heading: "Exo 2", sans-serif;
+  --body: "Exo 2", sans-serif;
   --code: "IBM Plex Mono", monospace;
 
   // font sizes

--- a/_styles/dark-toggle.scss
+++ b/_styles/dark-toggle.scss
@@ -1,31 +1,41 @@
 ---
 ---
 
-.dark-toggle {
-  position: relative;
-  width: 40px;
-  height: 25px;
-  margin: 0;
-  border-radius: 999px;
-  background: var(--primary);
-  appearance: none;
-  transition: background var(--transition);
+.theme-picker {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 0;
 }
 
-.dark-toggle:after {
-  content: "\f185";
-  position: absolute;
-  left: 12px;
-  top: 50%;
-  color: var(--text);
-  font-size: 15px;
-  font-family: "Font Awesome 6 Free";
-  font-weight: 900;
-  transform: translate(-50%, -50%);
-  transition: left var(--transition);
+.theme-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  background: var(--theme-dot, var(--primary));
+  cursor: pointer;
+  transition: transform var(--transition), border-color var(--transition), box-shadow var(--transition);
+  padding: 0;
+  opacity: 0.5;
 }
 
-.dark-toggle:checked:after {
-  content: "\f186";
-  left: calc(100% - 12px);
+.theme-dot:hover {
+  transform: scale(1.3);
+  opacity: 0.8;
 }
+
+.theme-dot.active {
+  border-color: var(--text);
+  opacity: 1;
+  box-shadow: 0 0 6px var(--theme-dot, var(--primary));
+}
+
+// set each dot's color to its theme's accent
+.theme-dot[data-theme="deep-space"] { background: #60a5fa; }
+.theme-dot[data-theme="nebula"] { background: #a78bfa; }
+.theme-dot[data-theme="aurora"] { background: #34d399; }
+.theme-dot[data-theme="solar-flare"] { background: #fbbf24; }
+.theme-dot[data-theme="ucf-knight"] { background: #ffc904; }
+.theme-dot[data-theme="lunar-surface"] { background: #94a3b8; }

--- a/contact/index.md
+++ b/contact/index.md
@@ -37,9 +37,13 @@ We're always looking for motivated researchers at all levels. See our [Opportuni
 
 {% include section.html %}
 
-## For Industry Partners
+## For Industry & Government Partners
 
-DRACO engages with industry through sponsored research, capstone project mentorship, and collaborative R&D. If you have a security challenge or are interested in partnering, reach out to [Dr. Borowczak](mailto:mike.borowczak@ucf.edu) directly.
+DRACO engages with organizations through sponsored research, capstone mentorship, and collaborative R&D — delivering tools, IP, and trained engineers. Whether you have a specific security challenge or want to invest in the next generation of hardware security talent, reach out to [Dr. Borowczak](mailto:mike.borowczak@ucf.edu) directly.
+
+## For Alumni & Supporters
+
+DRACO alumni are making an impact at AMD, Lockheed Martin, L3Harris, Collins Aerospace, Northrop Grumman, and beyond. Your support — whether through mentorship, collaboration, or giving — helps the next cohort of students access the same transformative research experience. Connect with us to get involved.
 
 {% include section.html %}
 

--- a/funding/index.md
+++ b/funding/index.md
@@ -7,7 +7,7 @@ nav:
 
 # {% include icon.html icon="fa-solid fa-hand-holding-dollar" %}Funding
 
-DRACO research is made possible through the support of federal agencies, industry partners, and university programs.
+Every dollar invested in DRACO funds student researchers, builds open-source security tools, and produces graduates ready to lead in industry and government. Our work is made possible through the support of federal agencies, industry partners, and the broader UCF community.
 
 {% include section.html %}
 

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@
 
 <div class="hero-tagline">Securing Systems.<br>From Silicon to Swarms.</div>
 
-<div class="hero-sub">Applied security research from logic gates to autonomous swarms. The <strong>DRACO</strong> (<strong>D</strong>esign of <strong>R</strong>esilient <strong>A</strong>rchitectures for <strong>C</strong>omputing) Lab at <a href="https://ucf.edu">UCF</a> automates the design, attack, and defense of computing systems — from side-channel-resistant architectures and AI-driven hardware Trojan detection to post-quantum cryptographic primitives and secure swarm coordination.</div>
+<div class="hero-sub">The <strong>DRACO</strong> (<strong>D</strong>esign of <strong>R</strong>esilient <strong>A</strong>rchitectures for <strong>C</strong>omputing) Lab at <a href="https://ucf.edu">UCF</a> partners with federal agencies and industry leaders to advance the security of computing systems — from side-channel-resistant architectures and AI-driven hardware Trojan detection to post-quantum cryptographic primitives and secure swarm coordination. Our students become the engineers who build what's next.</div>
 
 {%
   include button.html
@@ -35,7 +35,7 @@
   </div>
   <div class="stat">
     <span class="stat-number">11</span>
-    <span class="stat-label">Sponsors</span>
+    <span class="stat-label">Partners</span>
   </div>
 </div>
 
@@ -45,7 +45,7 @@
 
 {% capture text %}
 
-We develop automated methods to design, attack, and harden electronic devices and computing systems — spanning side-channel analysis, hardware Trojan detection, cryptographic primitive design, and secure autonomous coordination. With 100+ publications, nearly all of our work involves students as co-authors and collaborators.
+We develop automated methods to design, attack, and harden electronic devices and computing systems — spanning side-channel analysis, hardware Trojan detection, cryptographic primitive design, and secure autonomous coordination. With 100+ publications and students as co-authors on nearly every paper, our research directly builds the workforce that industry and government need.
 {%
   include button.html
   link="research"
@@ -67,9 +67,9 @@ We develop automated methods to design, attack, and harden electronic devices an
 
 {% capture text %}
 
-We work on a broad range of projects funded by federal and industry partners. While much of our work is open source, some may remain embargoed or partially redacted when necessary.
+Our portfolio of projects — backed by agencies like NSF, NSA, and DOE and companies like AMD and Northrop Grumman — translates directly into tools, IP, and trained talent. Much of our work is open source; some remains embargoed when required by sponsors.
 
-We have opportunities for undergraduate (paid or experiential, based on interest and time commitment) and graduate research (funded). Our research projects span hardware security, side-channel analysis, swarm intelligence, and cryptographic design, but we also sponsor applied projects that may be of interest to Senior Design Teams.
+Undergraduate and graduate students work side-by-side on real deliverables across hardware security, side-channel analysis, swarm intelligence, and cryptographic design. Our alumni hold positions at AMD, Lockheed Martin, L3Harris, Collins Aerospace, BAE Systems, and more.
 {%
   include button.html
   link="projects"
@@ -93,7 +93,7 @@ We have opportunities for undergraduate (paid or experiential, based on interest
 
 {% capture text %}
 
-We're an open and collaborative group — learn more about who we are!
+Researchers, mentors, and future industry leaders — meet the people behind the work and see where they go next.
 
 {%
   include button.html

--- a/opportunities/index.md
+++ b/opportunities/index.md
@@ -7,7 +7,7 @@ nav:
 
 # {% include icon.html icon="fa-solid fa-door-open" %}Join Us
 
-DRACO is always looking for motivated researchers who want to work on problems others hesitate to tackle. We value curiosity, initiative, and a willingness to learn across disciplines — from hardware design to machine learning to formal verification.
+DRACO is always looking for motivated researchers who want to work on problems others hesitate to tackle. Our students publish in top venues, contribute to federally funded projects, and graduate into roles at leading defense and technology companies. We value curiosity, initiative, and a willingness to learn across disciplines.
 
 {% include section.html %}
 
@@ -49,14 +49,14 @@ Browse available projects on the [Projects]({{ site.baseurl }}/projects) page an
 
 {% include section.html %}
 
-## Industry Collaboration
+## Industry & Government Partnerships
 
-DRACO partners with industry on sponsored research, red team assessments, and collaborative R&D. Our sponsors include NSF, NSA, DOE, Idaho National Laboratory, AMD, Northrop Grumman, Arctic Wolf, IOG, Kraken, and Ripple.
+DRACO works with organizations that need answers to hard security questions — and a pipeline of engineers trained to keep delivering them. Current and recent partners include NSF, NSA, DOE, Idaho National Laboratory, AMD, Northrop Grumman, Arctic Wolf, IOG, Kraken, and Ripple.
 
 **Partnership models:**
-- Sponsored research projects
-- Capstone project mentorship and sponsorship
-- Collaborative tool development
-- Consulting on hardware security and resilience
+- Sponsored research with defined deliverables and IP options
+- Capstone project mentorship — shape the next generation of engineers firsthand
+- Collaborative tool development and red team assessments
+- Early access to graduating talent trained on your problem domain
 
-Contact [Dr. Borowczak](mailto:mike.borowczak@ucf.edu) to discuss opportunities.
+Contact [Dr. Borowczak](mailto:mike.borowczak@ucf.edu) to explore what's possible.

--- a/projects/index.md
+++ b/projects/index.md
@@ -7,7 +7,7 @@ nav:
 
 # {% include icon.html icon="fa-solid fa-wrench" %}Projects
 
-Our research spans hardware security, side channel analysis, AI-assisted vulnerability assessment, secure autonomous systems, and cryptographic design. Below are active research projects and applied project ideas for senior design teams.
+Our research spans hardware security, side channel analysis, AI-assisted vulnerability assessment, secure autonomous systems, and cryptographic design. Each project below is backed by real partnerships, produces open deliverables, and trains the next generation of security engineers. Browse active research and applied project ideas for senior design teams.
 
 {% include tags.html tags="research, senior-design, available, undergraduate-research-spots, graduate-research-spots" %}
 

--- a/research/index.md
+++ b/research/index.md
@@ -7,9 +7,9 @@ nav:
 
 # {% include icon.html icon="fa-solid fa-microscope" %}Research
 
-DRACO investigates the security and resilience of computing systems at every level of abstraction — from transistor-level side channels to system-level threat models. Our applied research spans hardware security, side channel analysis, embedded systems, and AI-assisted vulnerability assessment. We also lead nationally recognized cybersecurity education programs from K-12 through graduate level.
+DRACO investigates the security and resilience of computing systems at every level of abstraction — from transistor-level side channels to system-level threat models. Our applied research spans hardware security, side channel analysis, embedded systems, and AI-assisted vulnerability assessment, delivering open-source tools, reproducible methodologies, and field-tested solutions to our partners.
 
-With a team of over a dozen active researchers, our work produces open-source tools, reproducible methodologies, and real-world impact through industry and government partnerships.
+With over a dozen active researchers and nationally recognized cybersecurity education programs from K-12 through graduate level, every project we undertake doubles as a talent pipeline — producing publications and production-ready engineers in parallel.
 
 {% include section.html size="full" %}
 

--- a/team/index.md
+++ b/team/index.md
@@ -7,9 +7,9 @@ nav:
 
 # {% include icon.html icon="fa-solid fa-users" %}Team
 
-The DRACO Laboratory in the Electrical and Computer Engineering Department within UCF's College of Engineering and Computer Science advances resilient computing architectures through research in side-channel security, hardware Trojan detection and insertion, AI-driven design automation for security, post-quantum cryptographic primitives, secure swarm coordination, and emerging paradigms such as encrypted processing and memristive computing.
+The DRACO Laboratory in UCF's Department of Electrical and Computer Engineering develops resilient computing architectures through research in side-channel security, hardware Trojan detection, AI-driven design automation, post-quantum cryptographic primitives, secure swarm coordination, and emerging paradigms such as encrypted processing and memristive computing.
 
-Our team welcomes researchers at all levels — from undergraduates to postdoctoral scholars — to engage in work spanning theoretical foundations to system-level implementations. Interested? See our [open opportunities]({{ site.baseurl }}/opportunities) or reach out with your resume and a brief statement about how your interests might intersect.
+Our team includes undergraduates through postdoctoral scholars — all gaining hands-on experience with the tools and challenges they'll face in careers at companies like AMD, Lockheed Martin, Northrop Grumman, and beyond. Interested? See our [open opportunities]({{ site.baseurl }}/opportunities) or reach out.
 
 {% include section.html %}
 ## Lab PI
@@ -53,7 +53,7 @@ Our team welcomes researchers at all levels — from undergraduates to postdocto
 
 ## Funding and Support
 
-The work, projects, publications, materials, and members represented have been funded by a variety of federal, state, local, and corporate entities. We appreciate their support and look forward to continuing to develop mutually beneficial relationships. Have a project you're interested in supporting? Contact [Dr. Mike]({{ site.baseurl }}/contact).
+Our research, tools, and student training are made possible through partnerships with federal, state, and corporate entities. These collaborations advance critical security research while giving partners early access to emerging talent, novel IP, and applied results. Interested in what a partnership looks like? Contact [Dr. Mike]({{ site.baseurl }}/contact).
 
 
 ### Sponsors


### PR DESCRIPTION
## Overview

This PR replaces the binary light/dark mode toggle with a comprehensive multi-theme color system featuring 6 distinct dark-themed palettes. It also updates typography to use Orbitron and Exo 2 fonts, and refreshes site copy to emphasize industry/government partnerships and student outcomes.

## Changes

### Theme System Redesign
- **Removed**: Binary `data-dark` light/dark toggle in favor of `data-theme` attribute
- **Added**: 6 new color themes:
  - Deep Space (default, blue palette)
  - Nebula (purple palette)
  - Aurora (green palette)
  - Solar Flare (orange/amber palette)
  - UCF Knight (gold palette)
  - Lunar Surface (slate palette)
- Each theme includes primary, secondary, accent, text, background, and overlay colors
- All themes are dark-mode only; `data-dark="true"` is now permanent

### UI Component Updates
- **Replaced**: Dark mode toggle checkbox with visual theme picker
- **New component**: `.theme-picker` with clickable color dots (`.theme-dot`)
- Each dot displays the theme's primary color and includes hover/active states
- Theme selection persists via localStorage (`color-theme` key)
- Dots are dynamically generated on page load with proper ARIA labels

### Typography
- **Updated fonts**:
  - Title: "Clash Display" → "Orbitron"
  - Heading: "DM Sans" → "Exo 2"
  - Body: "DM Sans" → "Exo 2"
  - Code: "IBM Plex Mono" (unchanged)
- Updated `_includes/fonts.html` to load new Google Fonts

### JavaScript
- Refactored `_scripts/dark-mode.js` to `color-theme` management
- Theme picker dots are built dynamically from a themes array
- `selectTheme()` function exposed globally for theme switching
- Saved theme loads before page render to prevent flash

### Content Updates
- Emphasized industry/government partnerships and student outcomes across multiple pages
- Updated "Sponsors" → "Partners" terminology
- Enhanced messaging around student career outcomes and workforce development
- Added new "Alumni & Supporters" section to contact page
- Refined partnership models and collaboration descriptions

### Configuration
- Updated `_layouts/default.html` to use `data-theme="deep-space"` as default
- Resolved merge conflict in `_config.yaml` (kept claude/analyze-jekyll-site branch description)

## Test Plan

- Verify all 6 theme dots appear in footer and are clickable
- Confirm theme selection persists across page reloads
- Check that Deep Space theme loads by default
- Validate new fonts (Orbitron, Exo 2) render correctly across headings and body text
- Ensure theme dots display correct colors and have proper hover/active states
- Test localStorage persistence of selected theme

This website is based on the Lab Website Template.
See its documentation for working with this site:

https://greene-lab.gitbook.io/lab-website-template-docs

https://claude.ai/code/session_01Fm3FbjYPapXZpdc69wbrFE