### PR TITLE
Add Umami analytics tracking

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,3 +1,1 @@
-<!--
-  put your analytics (e.g. Google Analytics) tracking code here
--->
+<script defer src="https://cloud.umami.is/script.js" data-website-id="2176cef2-57af-4fcf-b220-7b2050b694c3"></script>


### PR DESCRIPTION
## Summary
- Replace the placeholder `_includes/analytics.html` with the Umami tracking script (website id `2176cef2-57af-4fcf-b220-7b2050b694c3`).
- Loaded via `_includes/head.html`, so it ships on every page.

## Test plan
- [ ] `bundle exec jekyll serve` and confirm the `<script defer src="https://cloud.umami.is/script.js" ...>` tag appears in the rendered `<head>` on a few pages.
- [ ] After deploy, verify pageviews show up in the Umami dashboard.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PgCkd3CAesWA9wNAi3yFSF)_