### PR TITLE
Reorganize team page: surface mentors, sort and shrink alumni

### DIFF
--- a/_members/aaron-lingerfelt.md
+++ b/_members/aaron-lingerfelt.md
@@ -2,6 +2,8 @@
 name: Aaron Lingerfelt
 image: images/people/aaron-lingerfelt.jpg
 role: alumni
+date: 2024-05-01
+affiliation: Northrop Grumman
 sponsors: [ucf, northrop-grumman]
 links:
   linkedin: aaronlingerfelt

--- a/_members/davi-dantas.md
+++ b/_members/davi-dantas.md
@@ -2,6 +2,8 @@
 name: Davi Dantas
 image: images/people/davi-dantas-hd.jpg
 role: alumni
+date: 2025-05-01
+affiliation: BAE Systems
 sponsors: N/A
 links:
   home-page: N/A

--- a/_members/jarett-artman.md
+++ b/_members/jarett-artman.md
@@ -2,6 +2,7 @@
 name: Jarett Artman
 image: images/people/jarett-artman.jpg
 role: ms-alumni
+date: 2025-05-01
 sponsors: [ucf]
 links:
   home-page: http://jarettartman.com

--- a/_members/jenna-goodrich.md
+++ b/_members/jenna-goodrich.md
@@ -2,6 +2,7 @@
 name: Jenna Goodrich
 image: images/people/jenna-goodrich.jpg
 role: ms-alumni
+date: 2025-05-01
 sponsors: [ucf]
 group: 
 links:

--- a/_members/lana-perkins.md
+++ b/_members/lana-perkins.md
@@ -2,6 +2,8 @@
 name: Lana Perkins
 image: images/people/lana-perkins.jpg
 role: alumni
+date: 2024-05-01
+affiliation: L3Harris
 sponsors: [amd]
 group: AMD
 links:

--- a/_members/luckner-ablard.md
+++ b/_members/luckner-ablard.md
@@ -2,6 +2,8 @@
 name: Luckner Ablard
 image: images/people/luckner-ablard.jpeg
 role: alumni
+date: 2024-08-01
+affiliation: Collins Aerospace
 sponsors: [ucf]
 links:
   linkedin: luckner-ablard

--- a/_members/malia-rojas.md
+++ b/_members/malia-rojas.md
@@ -2,6 +2,8 @@
 name: Malia Rojas 
 image: images/people/malia_rojas.jpg
 role: alumni
+date: 2024-05-01
+affiliation: Lockheed Martin
 sponsors: [ucf]
 links:
   linkedin: malia-rojas  

--- a/_members/raul-graterol.md
+++ b/_members/raul-graterol.md
@@ -2,6 +2,7 @@
 name: Raul Graterol
 image: images/people/raul-graterol.jpg
 role: alumni
+date: 2025-05-01
 sponsors: [northrop-grumman]
 links:
   linkedin: www.linkedin.com/in/raul-graterol-509716241

--- a/_members/sheridan-sloan.md
+++ b/_members/sheridan-sloan.md
@@ -2,6 +2,8 @@
 name: Sheridan Sloan
 image: images/people/sheridan-sloan.png
 role: alumni
+date: 2024-05-01
+affiliation: Lockheed Martin
 sponsors: [ucf]
 links:
   linkedin: sheridan-sloan

--- a/_members/yvan-pierre.md
+++ b/_members/yvan-pierre.md
@@ -2,6 +2,8 @@
 name: Yvan Pierre
 image: images/people/yvan-pierre.jpg
 role: alumni
+date: 2024-05-01
+affiliation: Honeywell
 sponsors: [ucf]
 links:
   linkedin: ypjr

--- a/team/index.md
+++ b/team/index.md
@@ -12,9 +12,20 @@ The DRACO Laboratory in UCF's Department of Electrical and Computer Engineering 
 Our team includes undergraduates through postdoctoral scholars — all gaining hands-on experience with the tools and challenges they'll face in careers at companies like AMD, Lockheed Martin, Northrop Grumman, and beyond. Interested? See our [open opportunities]({{ site.baseurl }}/opportunities) or reach out.
 
 {% include section.html %}
+
+{% capture lab_pi %}
 ## Lab PI
 
 {% include list.html data="members" component="portrait" filters="role: PI" %}
+{% endcapture %}
+
+{% capture alumni_mentors %}
+## Alumni Mentors
+
+{% include list.html data="members" component="portrait" filters="role: alumni-mentor" %}
+{% endcapture %}
+
+{% include cols.html col1=lab_pi col2=alumni_mentors %}
 
 
 {% include section.html %}
@@ -36,29 +47,9 @@ Our team includes undergraduates through postdoctoral scholars — all gaining h
 {% include list.html data="members" component="portrait" filters="role: capstone-senior " %}
 
 {% include section.html %}
-## Alumni Mentors
-
-{% include list.html data="members" component="portrait" filters="role: alumni-mentor" %}
-
-{% include section.html %}
 ## Alumni
 
-{% include list.html data="members" component="portrait" filters="role: (ms-alumni|^alumni$)" %}
-
-
-### Alumni
-- Michael Castiglia, B.S., 2025 [AMD; UCF ECE MS Program]
-- Jarett Artman, M.S., 2025
-- Jenna Goodrich, M.S., 2025
-- Davi Dantas, B.S., 2025 [BAE Systems]
-- Raul Graterol, B.S., 2025
-- Malia Rojas, B.S., 2024 [Lockheed Martin]
-- Yvan Pierre, B.S., 2024 [Honeywell]
-- Luckner Ablard, B.S., 2024 [Collins Aerospace]
-- Francisco Soriano, B.S., 2024 [AMD; UCF Grad School]
-- Lana Perkins, BS, 2024 [L3Harris]
-- Sheridan Sloan, BS, 2024 [Lockheed Martin]
-- Aaron Lingerfelt, BS, 2024 [Northrop Grumman]
+{% include list.html data="members" component="portrait" filters="role: (ms-alumni|^alumni$)" style="small" %}
 
 {% include section.html %}
 


### PR DESCRIPTION
## Summary
- Pull **Alumni Mentors** to the top of the team page and place them side-by-side with the **Lab PI** using `cols.html`, so mentors are visible without scrolling past every student group.
- Render the **Alumni** gallery with the `style="small"` portrait variant (≈100px vs. 175px) so the section reads as a directory rather than the active-team roster.
- Add `date` (graduation year) and `affiliation` (post-grad employer, where known) front matter for the alumni that were previously listed only in the trailing markdown bullet list. Because `list.html` groups by year, alumni now display in **graduation-year bands** with their employer shown under each portrait.
- Remove the now-redundant text list of alumni — that information has been folded into the portrait cards.

## Files touched
- `team/index.md` — restructured the top of the page; dropped the bullet list; passes `style="small"` to the alumni list.
- `_members/*.md` — added `date` and `affiliation` for: aaron-lingerfelt, davi-dantas, jarett-artman, jenna-goodrich, lana-perkins, luckner-ablard, malia-rojas, raul-graterol, sheridan-sloan, yvan-pierre.

## Notes
- Alumni who don't yet have an explicit `date:` fall under the current build year heading. They're mostly current students who happen to be tagged `alumni`; assigning each a real grad year is a separate cleanup.
- Lab PI/Mentors column layout collapses to one column under 500px (existing `cols.scss` breakpoint), so mobile keeps the stacked appearance.

## Test plan
- [ ] Spot-check the rendered `/team/` page locally or on preview: PI + Mentors render in two columns at desktop width.
- [ ] Confirm alumni gallery shows year headings (2024, 2025, …) with shrunken portraits and affiliation text under each name.
- [ ] Verify mobile width collapses the PI/Mentor row to a single column.

https://claude.ai/code/session_01Ngy2rvZQ1bt38jPP2pTNVD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ngy2rvZQ1bt38jPP2pTNVD)_