### PR TITLE
Retune opportunities page to lead with industry & government partnerships

### DIFF
--- a/opportunities/index.md
+++ b/opportunities/index.md
@@ -1,62 +1,106 @@
 ---
-title: Opportunities
+title: Partner With Us
 nav:
   order: 4
-  tooltip: Join the lab
+  tooltip: Industry & government partnerships
 ---
 
-# {% include icon.html icon="fa-solid fa-door-open" %}Join Us
+# {% include icon.html icon="fa-solid fa-handshake" %}Partner With DRACO
 
-DRACO is always looking for motivated researchers who want to work on problems others hesitate to tackle. Our students publish in top venues, contribute to federally funded projects, and graduate into roles at leading defense and technology companies. We value curiosity, initiative, and a willingness to learn across disciplines.
+DRACO partners with **industry and government** to answer hard security questions — from silicon to swarms. We turn open problems into deliverables: hardened architectures, vetted designs, attack/defense tooling, red team assessments, and a pipeline of engineers already trained on your problem domain.
+
+If your team is sizing up a research gift, sponsoring directed research, scoping an R&D contract, or needs an outside red team that understands the hardware as well as the software — **let's talk.**
+
+{%
+  include button.html
+  link="mailto:mike.borowczak@ucf.edu?subject=DRACO%20Partnership%20Inquiry"
+  text="Start a partnership conversation"
+  icon="fa-solid fa-envelope"
+  flip=true
+%}
 
 {% include section.html %}
+
+## {% include icon.html icon="fa-solid fa-bullseye" %}Why DRACO
+
+- **Track record across the stack.** $7.7M awarded across 43 projects with federal agencies (NSF, NSA, DOE / Idaho National Laboratory), primes (Northrop Grumman, AMD, Leidos), and commercial security and Web3 partners (Arctic Wolf, Microsoft, Kraken, Ripple, IOHK).
+- **From logic gates to autonomous systems.** Side-channel analysis and countermeasures, hardware Trojan generation and detection, post-quantum and homomorphic primitives, superconducting/emerging-device logic, secure swarm coordination, and AI/LLM security (Shadow AI, Trace-AI).
+- **Cleared-ready, defense-aligned talent.** Our alumni land at AMD, Lockheed Martin, L3Harris, Collins Aerospace, BAE Systems, and Northrop Grumman. Sponsors get first-look access to the same talent before they hit the open market.
+- **Open or embargoed.** Most of our work is published and open-sourced; sensitive engagements stay embargoed when sponsors require it. We've operated under both for years.
+
+{% include section.html %}
+
+## {% include icon.html icon="fa-solid fa-network-wired" %}Ways to Engage
+
+We tailor each engagement to the partner's timeline, IP needs, and clearance posture. Common models include:
+
+- **Unrestricted gifts.** Lowest friction. Fund a directed thrust (e.g., side-channel of your IP block, ML-driven Trojan detection on your toolchain) without contractual deliverables. Eligible for FL High Tech Corridor 2:1 matching — your dollar can become three.
+- **Directed / sponsored research.** Defined scope, milestones, and IP terms, negotiated through UCF's Office of Research. Examples in flight or recently completed: AI-driven shadow-model risk, automated hardware Trojan benchmarking, superconducting logic synthesis automation.
+- **R&D subcontracts and prime contracts.** Multi-year federal and prime-led programs. We routinely team on DoD, DoE, NSF, and NSA-aligned solicitations and can stand up as PI or as a hardware/security subaward.
+- **Red teaming and security assessments.** Independent, university-led red team engagements against hardware, firmware, ML pipelines, or blockchain infrastructure. Deliverables include reproducible findings, mitigations, and a defensible written record.
+- **Capstone / senior design sponsorship.** Scope a real, contained problem; an ECE or CS senior design team builds and delivers it across two semesters with faculty oversight. Low cost, high signal for hiring.
+- **Talent pipeline & embedded internships.** Co-define a research thrust, then host the student(s) working it. Multiple sponsors have hired directly out of these engagements.
+- **Joint proposals.** We're an active partner on NSF, NSA, DOE, and DARPA-relevant solicitations and welcome industry letters of support, cost share, and primed/subbed teaming.
+
+{% include section.html %}
+
+## {% include icon.html icon="fa-solid fa-clock-rotate-left" %}Selected Collaborations
+
+A snapshot of recent and historical partners — see the [Funding]({{ site.baseurl }}/funding) page for the full list.
+
+**Hardware security & defense R&D**
+- *Northrop Grumman Corporation* — Automation for Superconducting Logic ($2M, PI, 60%) — synthesis and verification automation for superconducting / SFQ logic families.
+- *Idaho National Laboratory / DOE LDRD & INL-CAES* — multi-year engagements on resilient architectures and cyber-physical security for energy infrastructure.
+- *AMD, Lockheed Martin, L3Harris, Collins Aerospace, BAE Systems* — ongoing alumni placements and collaboration on trusted hardware and secure design.
+
+**AI, ML, and red teaming**
+- *Leidos* — Red Teaming ($100K, PI, 2025–2026) — adversarial assessment of AI/ML systems.
+- *Arctic Wolf Network* — Trace-AI ($100K, 2026–2027) and Shadow AI ($165K, 2024–2026) — AI/LLM threat detection and shadow-model risk, each paired with a 2:1 FL High Tech Corridor match.
+
+**Cryptography, blockchain, and trusted infrastructure**
+- *Kraken* — Research Support and Secure Blockchain Initiatives ($225K total, PI) — applied cryptography and exchange-side blockchain security.
+- *Ripple* — XRPL Validator and Smart Contracts research ($90K total, PI) — validator security and contract analysis on the XRP Ledger.
+- *IOHK / IOG* — Cardano-adjacent research on cryptographic primitives and protocol assurance.
+
+**Federal mission and workforce**
+- *National Science Foundation* — WySTACK ($600K, PI), CS For All: WySLICE ($1M, PI), and related awards on scalable, secure computing and CS workforce development.
+- *National Security Agency* — GenCyberWY ($325K, PI-LI) — cybersecurity workforce pipeline aligned to NSA priorities.
+- *Microsoft / Code.org* — regional infrastructure for security and CS education at scale.
+
+{% include section.html %}
+
+## {% include icon.html icon="fa-solid fa-circle-question" %}Common Questions
+
+**What does a typical engagement cost?**
+Gifts start in the low five figures and routinely unlock state matching. Directed research is usually $75K–$250K per year per thrust; multi-year R&D contracts and federal subawards scale from there. Capstone sponsorships are the lowest-cost on-ramp.
+
+**How is IP handled?**
+University standard terms apply by default; specific IP, publication, and embargo terms are negotiated through UCF's Office of Research. We have a track record of operating under both fully open and fully embargoed terms.
+
+**Can you work on sensitive or controlled material?**
+Yes, scoped appropriately. We work routinely with DoD primes and national labs and can structure engagements around export-control and clearance requirements.
+
+**How fast can we start?**
+Gifts and capstone projects can stand up in weeks. Directed research typically takes 4–8 weeks through contracting. Federal teaming follows the solicitation timeline.
+
+{% include section.html %}
+
+## {% include icon.html icon="fa-solid fa-paper-plane" %}Get in Touch
+
+Email [Dr. Mike Borowczak](mailto:mike.borowczak@ucf.edu?subject=DRACO%20Partnership%20Inquiry) with a few sentences on the problem you're trying to move, your rough timeline, and whether you're thinking gift, directed research, contract, or red team. We'll come back with a scoped one-pager and a path forward.
+
+{% include section.html %}
+
+# {% include icon.html icon="fa-solid fa-graduation-cap" %}Student Opportunities
+
+We're well-staffed with motivated student researchers, but we're always interested in standout candidates — especially those bringing skills our partners need.
 
 ## Graduate Research (MS & PhD)
 
-We have **funded** positions for graduate students working on active research projects. Current areas include:
+We periodically open **funded** positions tied to active sponsored projects. Areas of current interest include side-channel analysis, AI-driven hardware Trojan detection, post-quantum and homomorphic architectures, superconducting / emerging-device logic, and secure autonomous coordination.
 
-- Side channel analysis and countermeasures
-- AI-driven hardware Trojan generation and detection
-- Post-quantum cryptographic primitives
-- Encrypted/homomorphic processor architectures
-- Secure autonomous swarm coordination
-- Memristor security and emerging device architectures
+**To apply:** Email [Dr. Borowczak](mailto:mike.borowczak@ucf.edu) with your CV, 2–3 sentences on which research areas interest you and why, and any relevant coursework, projects, or publications.
 
-**What we look for:** Background in ECE, CS, or related fields. Experience with HDL (Verilog/VHDL), Python, or ML frameworks is a plus but not required — we'll teach you.
+## Undergraduate Research & Senior Design
 
-**To apply:** Email [Dr. Borowczak](mailto:mike.borowczak@ucf.edu) with:
-1. Your CV/resume
-2. A brief statement (2-3 sentences) on which research areas interest you and why
-3. Any relevant coursework, projects, or publications
-
-{% include section.html %}
-
-## Undergraduate Research
-
-We offer both **paid** and **experiential** (course credit) undergraduate research positions. This is a great way to get hands-on experience with real security research, co-author publications, and build a strong foundation for graduate school or industry.
-
-Many of our projects have open undergraduate spots — check the [Projects]({{ site.baseurl }}/projects) page and filter by "undergraduate-research-spots."
-
-**To apply:** Same process as graduate — email [Dr. Borowczak](mailto:mike.borowczak@ucf.edu) with your resume and interests.
-
-{% include section.html %}
-
-## Senior Design / Capstone Teams
-
-We sponsor applied project ideas suitable for ECE and CS senior design teams. These projects are hands-on, build real systems, and often connect to our broader research agenda.
-
-Browse available projects on the [Projects]({{ site.baseurl }}/projects) page and filter by "senior-design."
-
-{% include section.html %}
-
-## Industry & Government Partnerships
-
-DRACO works with organizations that need answers to hard security questions — and a pipeline of engineers trained to keep delivering them. Current and recent partners include NSF, NSA, DOE, Idaho National Laboratory, AMD, Northrop Grumman, Arctic Wolf, IOG, Kraken, and Ripple.
-
-**Partnership models:**
-- Sponsored research with defined deliverables and IP options
-- Capstone project mentorship — shape the next generation of engineers firsthand
-- Collaborative tool development and red team assessments
-- Early access to graduating talent trained on your problem domain
-
-Contact [Dr. Borowczak](mailto:mike.borowczak@ucf.edu) to explore what's possible.
+Paid and experiential (course-credit) undergraduate roles open as projects allow. Senior design / capstone teams should browse the [Projects]({{ site.baseurl }}/projects) page and filter by **senior-design** or **undergraduate-research-spots** for currently scoped ideas. Industry sponsors interested in *funding* a capstone team should reach out via the partnership contact above.


### PR DESCRIPTION
## Summary

Refocuses `/opportunities/` on **developing and recruiting industry and government partners** rather than students. Student opportunities remain on the page but move below the partnerships content.

### What changed

- **Page title / nav label:** `Opportunities` → `Partner With Us` (URL `/opportunities` preserved so existing links continue to work).
- **New lead:** value-prop intro, primary CTA email button, and a "Why DRACO" block citing the $7.7M / 43-project track record and stack span (silicon → swarms).
- **"Ways to Engage":** explicit engagement models the lab supports — unrestricted gifts (with FL High Tech Corridor 2:1 match callout), directed/sponsored research, R&D subcontracts and prime contracts, red teaming, capstone sponsorship, embedded internships / talent pipeline, and joint proposals.
- **"Selected Collaborations":** historical and active partners called out by name and grouped by theme:
  - Hardware security & defense R&D — Northrop Grumman (Superconducting Logic, $2M), Idaho National Laboratory / DOE LDRD & INL-CAES, AMD, Lockheed Martin, L3Harris, Collins Aerospace, BAE Systems
  - AI/ML & red teaming — Leidos (Red Teaming), Arctic Wolf (Trace-AI, Shadow AI)
  - Cryptography, blockchain & trusted infrastructure — Kraken, Ripple (XRPL), IOHK/IOG
  - Federal mission & workforce — NSF (WySTACK, WySLICE), NSA (GenCyberWY), Microsoft / Code.org
- **FAQ:** cost ranges, IP handling, sensitive/controlled work, time-to-start.
- **Student opportunities (now secondary):** condensed graduate and undergraduate/senior-design sections retained, with a note steering industry capstone sponsors back to the partnership contact.

## Test plan

- [ ] Build the Jekyll site and confirm `/opportunities/` renders without Liquid errors
- [ ] Confirm nav now shows "Partner With Us" in the correct position (`nav.order: 4`)
- [ ] Confirm existing inbound links from `team/index.md`, `contact/index.md`, and the homepage "Join the Lab" button still resolve to `/opportunities`
- [ ] Spot-check that selected-collaborations figures match `_data/funding.yaml`


---
_Generated by [Claude Code](https://claude.ai/code/session_0184mmJsXUV6TZjXzc6uBErV)_