### PR TITLE
Remove pending Northrop Grumman superconducting logic opportunity

### DIFF
--- a/opportunities/index.md
+++ b/opportunities/index.md
@@ -49,7 +49,6 @@ We tailor each engagement to the partner's timeline, IP needs, and clearance pos
 A snapshot of recent and historical partners — see the [Funding]({{ site.baseurl }}/funding) page for the full list.
 
 **Hardware security & defense R&D**
-- *Northrop Grumman Corporation* — Automation for Superconducting Logic ($2M, PI, 60%) — synthesis and verification automation for superconducting / SFQ logic families.
 - *Idaho National Laboratory / DOE LDRD & INL-CAES* — multi-year engagements on resilient architectures and cyber-physical security for energy infrastructure.
 - *AMD, Lockheed Martin, L3Harris, Collins Aerospace, BAE Systems* — ongoing alumni placements and collaboration on trusted hardware and secure design.
 


### PR DESCRIPTION
## Summary
- Drops the Northrop Grumman "Automation for Superconducting Logic" bullet from the Selected Collaborations list on the Partner With Us page, since it's still pending.

## Test plan
- [ ] Verify the bullet no longer appears under "Hardware security & defense R&D" on the opportunities page.
- [ ] Confirm surrounding bullets render correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PmNFdyivzmovwY8YfsCapd)_