### PR TITLE
Show degree and company on team page alumni portraits

### DIFF
--- a/_includes/list.html
+++ b/_includes/list.html
@@ -26,6 +26,7 @@
       include {{ include.component | append: ".html" }}
       affiliation=d.affiliation
       author=d.author
+      display_mode=include.display_mode
       authors=d.authors
       buttons=d.buttons
       caption=d.caption

--- a/_includes/portrait.html
+++ b/_includes/portrait.html
@@ -1,5 +1,5 @@
 {% if include.lookup %}
-  {% assign member = site.members 
+  {% assign member = site.members
     | where_exp: "member", "member.slug == include.lookup"
     | first
   %}
@@ -9,6 +9,38 @@
 
 {% assign primary_role = member.role | coerce_first %}
 {% assign type = site.data.types[primary_role] %}
+
+{% comment %}
+  Normalize role into an iterable list so we can detect mixed roles like
+  [ms, alumni] (a returning alum) or [ms-alumni, alumni-mentor].
+{% endcomment %}
+{% assign role_list = member.role | join: "," | split: "," %}
+{% assign is_alumni_view = false %}
+{% assign degrees_completed = "" | split: "," %}
+{% assign current_student_label = "" %}
+{% assign current_degree_label = "" %}
+{% for raw_role in role_list %}
+  {% assign r = raw_role | strip %}
+  {% if r == "alumni" %}
+    {% assign is_alumni_view = true %}
+    {% assign degrees_completed = degrees_completed | push: "B.S." %}
+  {% elsif r == "ms-alumni" %}
+    {% assign is_alumni_view = true %}
+    {% assign degrees_completed = degrees_completed | push: "M.S." %}
+  {% elsif r == "phd-alumni" %}
+    {% assign is_alumni_view = true %}
+    {% assign degrees_completed = degrees_completed | push: "Ph.D." %}
+  {% elsif r == "undergrad" %}
+    {% assign current_student_label = "Current B.S. Student" %}
+    {% assign current_degree_label = "Pursuing B.S." %}
+  {% elsif r == "ms" %}
+    {% assign current_student_label = "Current M.S. Student" %}
+    {% assign current_degree_label = "Pursuing M.S." %}
+  {% elsif r == "phd" %}
+    {% assign current_student_label = "Current Ph.D. Student" %}
+    {% assign current_degree_label = "Pursuing Ph.D." %}
+  {% endif %}
+{% endfor %}
 
 <div class="portrait-wrapper">
   <a
@@ -48,16 +80,38 @@
       </span>
     {% endif %}
 
-    {% if member.description or type %}
+    {% if include.display_mode == "alumni" and is_alumni_view %}
+      {% if degrees_completed.size > 0 %}
+        <span class="portrait-description">
+          {{ degrees_completed | join: ", " }}
+        </span>
+      {% endif %}
+      {% if member.affiliation %}
+        <span class="portrait-affiliation">
+          {{ member.affiliation }}
+        </span>
+      {% endif %}
+      {% if current_student_label != "" %}
+        <span class="portrait-affiliation">
+          {{ current_student_label }}
+        </span>
+      {% endif %}
+    {% elsif include.display_mode == "student" and current_degree_label != "" %}
       <span class="portrait-description">
-        {{ member.description | default: type.description }}
+        {{ current_degree_label }}
       </span>
-    {% endif %}
+    {% else %}
+      {% if member.description or type %}
+        <span class="portrait-description">
+          {{ member.description | default: type.description }}
+        </span>
+      {% endif %}
 
-    {% if member.affiliation %}
-      <span class="portrait-affiliation">
-        {{ member.affiliation }}
-      </span>
+      {% if member.affiliation %}
+        <span class="portrait-affiliation">
+          {{ member.affiliation }}
+        </span>
+      {% endif %}
     {% endif %}
   </a>
 </div>

--- a/team/index.md
+++ b/team/index.md
@@ -31,25 +31,25 @@ Our team includes undergraduates through postdoctoral scholars — all gaining h
 {% include section.html %}
 ## PhD Student Researchers
 
-{% include list.html data="members" component="portrait" filters="role: ^phd$" %}
+{% include list.html data="members" component="portrait" filters="role: ^phd$" display_mode="student" %}
 
 {% include section.html %}
 ## Masters Student Researchers
 
-{% include list.html data="members" component="portrait" filters="role: ^ms$" %}
+{% include list.html data="members" component="portrait" filters="role: ^ms$" display_mode="student" %}
 
 {% include section.html %}
 ## Undergraduate Students
 
-{% include list.html data="members" component="portrait" filters="role: undergrad" %}
+{% include list.html data="members" component="portrait" filters="role: undergrad" display_mode="student" %}
 
 
-{% include list.html data="members" component="portrait" filters="role: capstone-senior " %}
+{% include list.html data="members" component="portrait" filters="role: capstone-senior " display_mode="student" %}
 
 {% include section.html %}
 ## Alumni
 
-{% include list.html data="members" component="portrait" filters="role: (ms-alumni|^alumni$)" style="small" %}
+{% include list.html data="members" component="portrait" filters="role: (ms-alumni|^alumni$|phd-alumni)" style="small" display_mode="alumni" %}
 
 {% include section.html %}
 


### PR DESCRIPTION
## Summary

Differentiates what portrait metadata appears on the team page depending on which section a member is rendered in.

- **Alumni section** — for each member, shows the degree(s) they completed (B.S./M.S./Ph.D., derived from `alumni` / `ms-alumni` / `phd-alumni` roles), their company `affiliation` if set, and — for "returners" whose role is something like `[ms, alumni]` or `[phd, alumni]` — a `Current M.S./Ph.D. Student` tag in addition to any company. So a member with both a company AND a returning student role gets both lines.
- **Current student sections** (PhD / MS / Undergrad / capstone) — shows only the degree being pursued (`Pursuing B.S./M.S./Ph.D.`). Affiliation/description is suppressed there.
- **Other sections** (PI, alumni mentors, sponsors, lookup-style portraits in member/post/project pages) — unchanged. The new behavior is opt-in via a `display_mode` parameter, so nothing else regresses.

Implementation:
- `_includes/portrait.html` walks `member.role` (normalized via `join`/`split` so it handles both string and array forms), derives a completed-degree list and a current-student label, then renders based on `include.display_mode`.
- `_includes/list.html` threads `display_mode` through to the component include.
- `team/index.md` sets `display_mode="alumni"` on the Alumni list, `display_mode="student"` on the PhD/MS/Undergrad/capstone lists, and extends the alumni regex to also pick up `phd-alumni`.

## Test plan

- [ ] Verify the Alumni section shows e.g. "B.S." + "Northrop Grumman" for Aaron Lingerfelt, "M.S." for Cory Brynds, and "B.S." + "Current Ph.D. Student" for Franco Mezzarapa (role `[phd, alumni]`).
- [ ] Verify Jordan Merkel and Robert Lee (role `[ms, alumni]`) show "B.S." + "Current M.S. Student".
- [ ] Verify a member with both `affiliation` and a returner role shows both lines.
- [ ] Verify the PhD / MS / Undergrad sections show only "Pursuing Ph.D." / "Pursuing M.S." / "Pursuing B.S." with no affiliation.
- [ ] Verify the Lab PI, Alumni Mentors, and Sponsors sections are unchanged.
- [ ] Verify individual member pages, post bylines, and project portraits (tiny style, lookup mode) are unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9h7946H4A3ARPH68ug9ht)_