### PR TITLE
Add Calvin VanWormer's Spring 2026 graduation date

### DIFF
--- a/_members/calvin-vanwormer.md
+++ b/_members/calvin-vanwormer.md
@@ -2,6 +2,7 @@
 name: Calvin VanWormer
 image: images/people/calvin-vanwormer.jpg
 role: ms-alumni
+date: 2026-05-01
 sponsors: [ucf, leidos]
 links:
   linkedin: calvin-vanwormer


### PR DESCRIPTION
Calvin VanWormer graduated with his master's in Spring 2026 (confirmed by Dr. Borowczak). His bio and `ms-alumni` role were already updated in #57; this adds his graduation `date: 2026-05-01` so he groups under **2026** in the team-page alumni list instead of falling back to the site build year.

One-line front-matter change to `_members/calvin-vanwormer.md`.

Supersedes #58 (same change, fresh branch).

https://claude.ai/code/session_01GUfAMx3oZ17kMzaTx6BVN3

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUfAMx3oZ17kMzaTx6BVN3)_