### PR TITLE
Reconcile roster with Airtable: MS transitions and broken-role fixes

### DIFF
--- a/_members/daniel-odi.md
+++ b/_members/daniel-odi.md
@@ -1,11 +1,11 @@
 ---
 name: Daniel Odi
 image: images/people/daniel-odi.png
-role: undergrad
+role: ms
 sponsors: [ucf]
 links:
   linkedin: danielodi
   orcid: 0009-0002-3349-9285
 ---
 
-Daniel Odi is a Computer Engineering student at the University of Central Florida focusing on VLSI design, FPGA/ASIC development, and hardware security. He has experience in RTL design and verification and has worked on secure embedded systems at Northrop Grumman, where he helped configure firmware and hardware platforms and develop distributed applications for embedded environments. Daniel is passionate about computer architecture, embedded systems, and designing reliable, secure hardware.
+Daniel Odi is a Computer Engineering graduate student at the University of Central Florida focusing on VLSI design, FPGA/ASIC development, and hardware security. He has experience in RTL design and verification and has worked on secure embedded systems at Northrop Grumman, where he helped configure firmware and hardware platforms and develop distributed applications for embedded environments. Daniel is passionate about computer architecture, embedded systems, and designing reliable, secure hardware.

--- a/_members/dylan-wilkins.md
+++ b/_members/dylan-wilkins.md
@@ -1,7 +1,7 @@
 ---
 name: Dylan Wilkins
 image: images/people/dylan-wilkins.jpg
-role: Undergraduate
+role: undergrad
 sponsors: [UCF]
 links:
   home-page: http://URLHERE

--- a/_members/lakshmi-ramanathan.md
+++ b/_members/lakshmi-ramanathan.md
@@ -1,9 +1,10 @@
+---
 name: Lakshmi Ramanathan
 image: images/people/lakshmi-ramanathan.jpg
-role: MS
-sponsors: [ucf , others-if-known]
+role: ms
+sponsors: [ucf]
 links:
-  home-page: https://www.linkedin.com/in/lakshmi-ramanathan-981282185/
-  linkedin: Lakshmi Ramanathan
+  linkedin: lakshmi-ramanathan-981282185
   github: Lakshmi-RM
-  orcid: N/A
+
+---

--- a/_members/matias-segura.md
+++ b/_members/matias-segura.md
@@ -1,11 +1,11 @@
 ---
 name: Matias Segura
 image: images/people/matias-segura.png
-role: undergrad
+role: ms
 sponsors: [ucf]
 links:
 
 
 ---
 
-Matias Segura is a Computer Engineering undergraduate student at the University of Central Florida. He joined the DRACO Laboratory to gain hands-on research experience in hardware security, computer architecture, and embedded systems.
+Matias Segura is a Computer Engineering graduate student at the University of Central Florida. He joined the DRACO Laboratory to gain hands-on research experience in hardware security, computer architecture, and embedded systems.


### PR DESCRIPTION
Reconciled the site roster against the DRACO Airtable `Researchers` table for the two cleanups requested — hiding inactive members and updating people who transitioned to MS or graduated to alumni.

## MS transitions (undergrad → ms)

Both are `Current Academic Level = Graduate`, `Lab Status = Active` in Airtable but were still listed as undergrads:

| Member | Change |
|---|---|
| Daniel Odi | `role: undergrad → ms`; bio "student" → "graduate student" |
| Matias Segura | `role: undergrad → ms`; bio "undergraduate student" → "graduate student" |

## Broken roster entries fixed (found during reconciliation)

The team-page role filters are **case-sensitive** regexes (`/^ms$/`, `/undergrad/`), so these two were silently excluded from the site:

- **Dylan Wilkins** — `role: Undergraduate` → `undergrad`. Capitalized value didn't match `/undergrad/`, so he was missing from the Undergraduate section.
- **Lakshmi Ramanathan** — her file had **no `---` front-matter delimiters** (it began at `name:`), so Jekyll never parsed it as a member — she wasn't rendering at all. Rebuilt valid front matter, set `role: MS → ms`, and fixed a broken `linkedin` value (was `Lakshmi Ramanathan`, a name, not a URL slug). No bio prose exists in Airtable for her, so the entry is intentionally bio-less like other minimal entries.

## No changes needed (verified against Airtable)

- **Hide inactive → 0 changes.** All 14 researchers with `Lab Status = Inactive` are already underscore-hidden (11 pre-existing + the 7 added in #60, minus overlap).
- **Graduated → alumni → 0 changes.** Every researcher with `Lab Status = Lab Alumni` or `Current Academic Level = Alumni` (25 people) already carries an alumni role (`alumni` / `ms-alumni`) with a graduation date.

## FYI (not changed — Airtable is the source of truth)

A few researchers list a 2026 graduation year and a post-grad employer (e.g. Jarred Long → Apple) but are still `Lab Status = Active` in Airtable, so they remain in the current-student sections. If any of them should move to alumni, updating their **Lab Status** in Airtable is the right lever and I can sync the site.

This website is based on the [Lab Website Template](https://greene-lab.gitbook.io/lab-website-template-docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJNjAt6Eu9Z8HRdgS8ZAU6

---
_Generated by [Claude Code](https://claude.ai/code/session_01UJNjAt6Eu9Z8HRdgS8ZAU6)_